### PR TITLE
Re-raise SignalException in Supervisor, so it reacts to signals properly

### DIFF
--- a/lib/pencil/supervisor.rb
+++ b/lib/pencil/supervisor.rb
@@ -21,7 +21,7 @@ module Pencil
 
     def run
       runnable.call
-    rescue SystemExit, Interrupt
+    rescue SystemExit, Interrupt, SignalException
       raise
     rescue Exception => e
       Pencil.logger.error("Supervisor: rescued error #{e.inspect}")


### PR DESCRIPTION
This PR adds `SignalException` to the list of re-raised exceptions of `Supervisor`. This allows service to react correctly to signals from outside world, for example, from `upstart`.
