### PR TITLE
Proposed change to sort hash entries by host_port

### DIFF
--- a/lib/pencil/docker.rb
+++ b/lib/pencil/docker.rb
@@ -16,7 +16,7 @@ module Pencil
         env = container['Config']['Env'] || []
         tags = extract_tags(env)
 
-        ports.each do |service_port, host_port|
+        ports.entries.sort { |a,b| a[1] <=> b[1] }.each do |service_port, host_port|
           unless host_port.nil?
             s_port = service_port.split('/').first
             h_port = host_port.first['HostPort']


### PR DESCRIPTION
Per request from @koshelev, sorting the hash entries by host_port to ensure that the entries are processed in ascending order of port number. I've not tested this - this is just a guess.